### PR TITLE
GP-37188: Fix custom supportcase tokens on latest civi versions

### DIFF
--- a/Civi/Supportcase/Hook/EvaluateTokens.php
+++ b/Civi/Supportcase/Hook/EvaluateTokens.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Civi\Supportcase\Hook;
+
+use API_Exception;
+use Civi\Token\Event\TokenValueEvent;
+use Civi\Token\TokenRow;
+use CRM_Core_Session;
+class EvaluateTokens {
+
+  /**
+   * @param TokenValueEvent $e
+   * @return void
+   */
+  public static function run(\Civi\Token\Event\TokenValueEvent $e) {
+    $currentContactId = CRM_Core_Session::getLoggedInContactID();
+    $addresseeDisplay = '';
+    $displayName = '';
+
+    try {
+      $contact = \Civi\Api4\Contact::get(FALSE)
+        ->addSelect('display_name', 'addressee_display')
+        ->addWhere('id', '=', $currentContactId)
+        ->execute()
+        ->first();
+
+      $displayName = $contact['display_name'];
+      $addresseeDisplay = $contact['addressee_display'];
+    } catch (API_Exception $e) {}
+
+    foreach ($e->getRows() as $row) {
+      /** @var TokenRow $row */
+      $row->format('text/html');
+      $row->tokens('supportcase_user', 'addressee', $addresseeDisplay);
+      $row->tokens('supportcase_user', 'display_name', $displayName);
+    }
+  }
+
+}

--- a/Civi/Supportcase/Hook/RegisterTokens.php
+++ b/Civi/Supportcase/Hook/RegisterTokens.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Civi\Supportcase\Hook;
+
+use Civi\Token\Event\TokenRegisterEvent;
+
+class RegisterTokens {
+
+  /**
+   * @param TokenRegisterEvent $e
+   * @return void
+   */
+  public static function run(\Civi\Token\Event\TokenRegisterEvent $e) {
+    $e->entity('supportcase_user')
+      ->register('addressee', ts('Addressee of logged in contact'))
+      ->register('display_name', ts('Display name of logged in contact'));
+  }
+
+}

--- a/supportcase.php
+++ b/supportcase.php
@@ -4,6 +4,8 @@ require_once 'supportcase.civix.php';
 
 use Civi\Api4\CiviCase;
 use CRM_Supportcase_ExtensionUtil as E;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\Resource\FileResource;
 
 /**
  * Implements hook_civicrm_config().
@@ -116,6 +118,21 @@ function supportcase_civicrm_permission(&$permissions) {
       E::ts('Access support cases'),
     ],
   ];
+}
+
+/**
+ * Add token services to the container.
+ *
+ * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+ */
+function  supportcase_civicrm_container(ContainerBuilder $container) {
+  $container->addResource(new FileResource(__FILE__));
+  $container->findDefinition('dispatcher')->addMethodCall('addListener',
+    ['civi.token.list', ['\Civi\Supportcase\Hook\RegisterTokens', 'run'], -100]
+  )->setPublic(TRUE);
+  $container->findDefinition('dispatcher')->addMethodCall('addListener',
+    ['civi.token.eval', ['\Civi\Supportcase\Hook\EvaluateTokens', 'run'], -100]
+  )->setPublic(TRUE);
 }
 
 function supportcase_civicrm_alterAPIPermissions($entity, $action, &$params, &$permissions) {


### PR DESCRIPTION
- Redeclaralate `supportcase_user.addressee` and `supportcase_user.display_name` tokens using `token processor methodology` instead of using `hook_civicrm_tokenValues`.
- Old version  by using `hook_civicrm_tokenValues` - haven't removed to support old versions of civi.