### PR TITLE
GP-41423: Add missed styles

### DIFF
--- a/css/ang/directives/communication.css
+++ b/css/ang/directives/communication.css
@@ -456,3 +456,7 @@
 .com__list-emails-loading-block {
   padding: 20px 0;
 }
+
+.comm__attachment-uploader-wrap .crm-attachments table tr td a.crm-hover-button[ng-click="item.remove()"] {
+  display: none !important;
+}


### PR DESCRIPTION
1. Add missed style: it hides cancel button while uploading email attachments. This button doesn't work correctly.